### PR TITLE
Try to add python 3 support

### DIFF
--- a/octoprint_excluderegion/ExcludeRegionState.py
+++ b/octoprint_excluderegion/ExcludeRegionState.py
@@ -769,7 +769,7 @@ class ExcludeRegionState(object):  # pylint: disable=too-many-instance-attribute
         returnCommands = []
 
         if (self.pendingCommands):
-            for gcode, cmdArgs in self.pendingCommands.iteritems():
+            for gcode, cmdArgs in self.pendingCommands.items():
                 if (isinstance(cmdArgs, Mapping)):
                     returnCommands.append(
                         self.gcodeParser.buildCommand(gcode, **cmdArgs)

--- a/octoprint_excluderegion/GcodeParser.py
+++ b/octoprint_excluderegion/GcodeParser.py
@@ -507,7 +507,7 @@ class GcodeParser(CommonMixin):  # pylint: disable=too-many-instance-attributes
         """
         vals = []
         if (paramsDict is not None):
-            for key, val in paramsDict.iteritems():
+            for key, val in paramsDict.items():
                 if (val is not None):
                     key += str(val)
 

--- a/octoprint_excluderegion/__init__.py
+++ b/octoprint_excluderegion/__init__.py
@@ -55,6 +55,7 @@ from .AtCommandAction import AtCommandAction, ENABLE_EXCLUSION, DISABLE_EXCLUSIO
 __plugin_name__ = "Exclude Region"
 __plugin_implementation__ = None
 __plugin_hooks__ = None
+__plugin_pythoncompat__ = ">=2.7,<4"
 
 EXCLUDED_REGIONS_CHANGED = "ExcludedRegionsChanged"
 


### PR DESCRIPTION
Due to missing python experience I basically run 2to3 on all python files but only commited the non-testing files. In the unit tests 2to3 wants changes like:
```
-        self.assertRegexpMatches(unit.id, "^[-0-9a-fA-F]{36}$", "id should be a UUID string")
+        self.assertRegex(unit.id, "^[-0-9a-fA-F]{36}$", "id should be a UUID string")
```
But as I dont know if this might break python 2 compability and those changes where only for test files I left them untouched.
The plugin loads as expected in octoprint with python 3 but I did not yet try if functionallity works too.