### PR TITLE
Python 3.10 compatibility

### DIFF
--- a/octoprint_excluderegion/ExcludeRegionState.py
+++ b/octoprint_excluderegion/ExcludeRegionState.py
@@ -5,7 +5,8 @@ from __future__ import absolute_import, division
 
 import logging
 import time
-from collections import OrderedDict, Mapping
+from collections import OrderedDict
+from collections.abc import Mapping
 
 from .ExcludedGcode import EXCLUDE_EXCEPT_FIRST, EXCLUDE_EXCEPT_LAST, EXCLUDE_MERGE
 from .Position import Position


### PR DESCRIPTION
Move Mapping to collections.abc (from collections) to fix following error with python 3.10:

```
2022-01-12 19:52:44,119 - octoprint.plugin.core - ERROR - Error loading plugin excluderegion
Traceback (most recent call last):
  File "/home/octoprint/venv/lib/python3.10/site-packages/octoprint/plugin/core.py", line 1291, in _import_plugin
    module = _load_module(module_name, spec)
  File "/home/octoprint/venv/lib/python3.10/site-packages/octoprint/plugin/core.py", line 68, in _load_module
    return imp.load_module(name, f, filename, details)
  File "/home/octoprint/venv/lib/python3.10/site-packages/octoprint/vendor/imp.py", line 238, in load_module
    return load_package(name, filename)
  File "/home/octoprint/venv/lib/python3.10/site-packages/octoprint/vendor/imp.py", line 212, in load_package
    return _load(spec)
  File "<frozen importlib._bootstrap>", line 719, in _load
  File "<frozen importlib._bootstrap>", line 688, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 883, in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/octoprint/venv/lib/python3.10/site-packages/octoprint_excluderegion/__init__.py", line 48, in <module>
    from .ExcludeRegionState import ExcludeRegionState
  File "/home/octoprint/venv/lib/python3.10/site-packages/octoprint_excluderegion/ExcludeRegionState.py", line 8, in <module>
    from collections import OrderedDict, Mapping
ImportError: cannot import name 'Mapping' from 'collections' (/usr/lib/python3.10/collections/__init__.py)
```