### PR TITLE
Remove pkg_resources version parsing

### DIFF
--- a/octoprint_excluderegion/__init__.py
+++ b/octoprint_excluderegion/__init__.py
@@ -38,8 +38,6 @@ import re
 import flask
 from flask_login import current_user
 
-import pkg_resources
-
 import octoprint.plugin
 from octoprint.events import Events
 from octoprint.settings import settings
@@ -62,6 +60,43 @@ EXCLUDED_REGIONS_CHANGED = "ExcludedRegionsChanged"
 LOG_MODE_OCTOPRINT = "octoprint"
 LOG_MODE_DEDICATED = "dedicated"
 LOG_MODE_BOTH = "both"
+
+GCODE_VIEWER_RENDERER_FIX_VERSION = (1, 3, 10)
+PRERELEASE_ORDER = {
+    "dev": 0,
+    "a": 1,
+    "b": 2,
+    "rc": 3
+}
+
+
+def _needs_legacy_gcode_viewer_renderer(version):
+    """Return whether an OctoPrint version predates the bundled gcode viewer fix."""
+    match = re.match(r"^(\d+)\.(\d+)\.(\d+)(?:(dev|a|b|rc)(\d+))?", version)
+
+    if (match is None):
+        return False
+
+    release = (
+        int(match.group(1)),
+        int(match.group(2)),
+        int(match.group(3))
+    )
+
+    if (release != GCODE_VIEWER_RENDERER_FIX_VERSION):
+        return release < GCODE_VIEWER_RENDERER_FIX_VERSION
+
+    prerelease = match.group(4)
+    if (prerelease is None):
+        return False
+
+    prereleaseNumber = int(match.group(5) or 0)
+    prereleaseOrder = PRERELEASE_ORDER.get(prerelease)
+
+    if (prereleaseOrder is None):
+        return False
+
+    return (prereleaseOrder, prereleaseNumber) < (PRERELEASE_ORDER["rc"], 1)
 
 
 # pylint: disable=global-statement
@@ -162,12 +197,10 @@ class ExcludeRegionPlugin(  # pylint: disable=too-many-instance-attributes
 
     def get_assets(self):
         """Define the static assets the plugin offers."""
-        octoprintVersion = pkg_resources.parse_version(octoprint.__version__)
-
         jsFiles = ["js/excluderegion.js"]
 
         # The modified gcode renderer is not needed for 1.3.10rc1 and above
-        if (octoprintVersion < pkg_resources.parse_version("1.3.10rc1")):
+        if (_needs_legacy_gcode_viewer_renderer(octoprint.__version__)):
             self._logger.info(
                 "Octoprint {} is pre 1.3.10rc1, including renderer.js to override gcode viewer",
                 octoprint.__display_version__

--- a/test/test_ExcludeRegionPlugin.py
+++ b/test/test_ExcludeRegionPlugin.py
@@ -15,7 +15,7 @@ from octoprint.settings import settings as octoprintSettings
 from octoprint_excluderegion import \
     ExcludeRegionPlugin, ExcludeRegionState, GcodeHandlers, \
     RectangularRegion, CircularRegion, \
-    EXCLUDED_REGIONS_CHANGED
+    EXCLUDED_REGIONS_CHANGED, _needs_legacy_gcode_viewer_renderer
 
 from .utils import TestCase
 
@@ -156,6 +156,22 @@ class ExcludeRegionPluginTests(TestCase):  # pylint: disable=too-many-public-met
 
         self._test_get_assets("1.3.9", additional_validations)
 
+    def test_get_assets_octoprint1_3_10rc0(self):
+        """Test the get_assets method under OctoPrint 1.3.10rc0."""
+        def additional_validations(result):
+            self.assertEqual(len(result["js"]), 2, "Two js assets should be returned")
+            self.assertEqual(len(result["css"]), 1, "One CSS asset should be returned")
+
+        self._test_get_assets("1.3.10rc0", additional_validations)
+
+    def test_get_assets_octoprint1_3_10rc1(self):
+        """Test the get_assets method under OctoPrint 1.3.10rc1."""
+        def additional_validations(result):
+            self.assertEqual(len(result["js"]), 1, "One js asset should be returned")
+            self.assertEqual(len(result["css"]), 1, "One CSS asset should be returned")
+
+        self._test_get_assets("1.3.10rc1", additional_validations)
+
     def test_get_assets_octoprint1_3_10(self):
         """Test the get_assets method under OctoPrint 1.3.10 or newer."""
         def additional_validations(result):
@@ -163,6 +179,20 @@ class ExcludeRegionPluginTests(TestCase):  # pylint: disable=too-many-public-met
             self.assertEqual(len(result["css"]), 1, "One CSS asset should be returned")
 
         self._test_get_assets("1.3.10", additional_validations)
+
+    def test_needs_legacy_gcode_viewer_renderer(self):
+        """Test the OctoPrint version check used by get_assets."""
+        self.assertTrue(_needs_legacy_gcode_viewer_renderer("1.3.9"))
+        self.assertTrue(_needs_legacy_gcode_viewer_renderer("1.3.10dev1"))
+        self.assertTrue(_needs_legacy_gcode_viewer_renderer("1.3.10a1"))
+        self.assertTrue(_needs_legacy_gcode_viewer_renderer("1.3.10b1"))
+        self.assertTrue(_needs_legacy_gcode_viewer_renderer("1.3.10rc0"))
+
+        self.assertFalse(_needs_legacy_gcode_viewer_renderer("1.3.10rc1"))
+        self.assertFalse(_needs_legacy_gcode_viewer_renderer("1.3.10rc2"))
+        self.assertFalse(_needs_legacy_gcode_viewer_renderer("1.3.10"))
+        self.assertFalse(_needs_legacy_gcode_viewer_renderer("1.4.0"))
+        self.assertFalse(_needs_legacy_gcode_viewer_renderer("unparseable"))
 
     # ~~ TemplatePlugin
 


### PR DESCRIPTION
## Summary
- Remove the top-level `pkg_resources` import used only for OctoPrint version parsing.
- Preserve the legacy renderer behavior for OctoPrint versions before `1.3.10rc1` with a small local parser.
- Add regression coverage for the `1.3.10rc0` / `1.3.10rc1` boundary.

Fixes #81

## Validation
- `git diff --check HEAD~1..HEAD`
- Not run locally: test suite