### PR TITLE
Octoprint 2.0.0 fixes

### DIFF
--- a/octoprint_excluderegion/__init__.py
+++ b/octoprint_excluderegion/__init__.py
@@ -341,7 +341,7 @@ class ExcludeRegionPlugin(  # pylint: disable=too-many-instance-attributes
 
     def on_api_command(self, command, data):
         """Route API requests to their implementations."""
-        if current_user.is_anonymous():
+        if current_user.is_anonymous:
             return "Insufficient rights", 403
 
         self._logger.debug("API command received: %s", data)

--- a/octoprint_excluderegion/__init__.py
+++ b/octoprint_excluderegion/__init__.py
@@ -186,6 +186,12 @@ class ExcludeRegionPlugin(  # pylint: disable=too-many-instance-attributes
             dict(type="settings", custom_bindings=True)
         ]
 
+    def is_template_autoescaped(self):
+        """
+        Enable template autoescaping
+        """
+        return True
+
     # ~~ SettingsPlugin
 
     def get_settings_defaults(self):

--- a/octoprint_excluderegion/__init__.py
+++ b/octoprint_excluderegion/__init__.py
@@ -38,11 +38,10 @@ import re
 import flask
 from flask_login import current_user
 
-import pkg_resources
-
 import octoprint.plugin
 from octoprint.events import Events
 from octoprint.settings import settings
+from octoprint.util.version import get_comparable_version
 
 from .GcodeHandlers import GcodeHandlers
 from .ExcludeRegionState import ExcludeRegionState
@@ -162,12 +161,12 @@ class ExcludeRegionPlugin(  # pylint: disable=too-many-instance-attributes
 
     def get_assets(self):
         """Define the static assets the plugin offers."""
-        octoprintVersion = pkg_resources.parse_version(octoprint.__version__)
+        octoprintVersion = get_comparable_version(octoprint.__version__)
 
         jsFiles = ["js/excluderegion.js"]
 
         # The modified gcode renderer is not needed for 1.3.10rc1 and above
-        if (octoprintVersion < pkg_resources.parse_version("1.3.10rc1")):
+        if (octoprintVersion < get_comparable_version("1.3.10rc1")):
             self._logger.info(
                 "Octoprint {} is pre 1.3.10rc1, including renderer.js to override gcode viewer",
                 octoprint.__display_version__

--- a/octoprint_excluderegion/__init__.py
+++ b/octoprint_excluderegion/__init__.py
@@ -272,6 +272,12 @@ class ExcludeRegionPlugin(  # pylint: disable=too-many-instance-attributes
 
     # ~~ SimpleApiPlugin
 
+    def is_api_protected(self):
+        """
+        Check authentication on API calls
+        """
+        return True
+
     def get_api_commands(self):
         """
         Define the POST command API endpoints for the plugin.

--- a/test/test_ExcludeRegionPlugin.py
+++ b/test/test_ExcludeRegionPlugin.py
@@ -194,7 +194,7 @@ class ExcludeRegionPluginTests(TestCase):  # pylint: disable=too-many-public-met
     @mock.patch('octoprint_excluderegion.current_user')
     def test_on_api_command_unauthenticated(self, mockCurrentUser):
         """Test on_api_command when the current user is not authenticated."""
-        mockCurrentUser.is_anonymous.return_value = True
+        mockCurrentUser.is_anonymous = True
 
         unit = create_plugin_instance()
 
@@ -209,7 +209,7 @@ class ExcludeRegionPluginTests(TestCase):  # pylint: disable=too-many-public-met
     @mock.patch('octoprint_excluderegion.current_user')
     def test_on_api_command_unknownCommand(self, mockCurrentUser):
         """Test on_api_command when an invalid command is provided."""
-        mockCurrentUser.is_anonymous.return_value = False
+        mockCurrentUser.is_anonymous = False
 
         unit = create_plugin_instance()
 
@@ -224,7 +224,7 @@ class ExcludeRegionPluginTests(TestCase):  # pylint: disable=too-many-public-met
     @mock.patch('octoprint_excluderegion.current_user')
     def test_on_api_command_addExcludeRegion_RectangularRegion(self, mockCurrentUser):
         """Test on_api_command for the 'addExcludeRegion' command and a RectangularRegion."""
-        mockCurrentUser.is_anonymous.return_value = False
+        mockCurrentUser.is_anonymous = False
 
         unit = create_plugin_instance()
         with mock.patch.object(unit, '_handleAddExcludeRegion') as handlerMock:
@@ -247,7 +247,7 @@ class ExcludeRegionPluginTests(TestCase):  # pylint: disable=too-many-public-met
     @mock.patch('octoprint_excluderegion.current_user')
     def test_on_api_command_addExcludeRegion_CircularRegion(self, mockCurrentUser):
         """Test on_api_command for the 'addExcludeRegion' command and a CircularRegion."""
-        mockCurrentUser.is_anonymous.return_value = False
+        mockCurrentUser.is_anonymous = False
 
         unit = create_plugin_instance()
         with mock.patch.object(unit, '_handleAddExcludeRegion') as handlerMock:
@@ -269,7 +269,7 @@ class ExcludeRegionPluginTests(TestCase):  # pylint: disable=too-many-public-met
     @mock.patch('octoprint_excluderegion.current_user')
     def test_on_api_command_addExcludeRegion_unsupportedType(self, mockCurrentUser):
         """Test on_api_command when an invalid type is provided for 'addExcludeRegion'."""
-        mockCurrentUser.is_anonymous.return_value = False
+        mockCurrentUser.is_anonymous = False
 
         unit = create_plugin_instance()
         with mock.patch.object(unit, '_handleAddExcludeRegion') as handlerMock:
@@ -290,7 +290,7 @@ class ExcludeRegionPluginTests(TestCase):  # pylint: disable=too-many-public-met
     @mock.patch('octoprint_excluderegion.current_user')
     def test_on_api_command_updateExcludeRegion_RectangularRegion(self, mockCurrentUser):
         """Test on_api_command for the 'updateExcludeRegion' command and a RectangularRegion."""
-        mockCurrentUser.is_anonymous.return_value = False
+        mockCurrentUser.is_anonymous = False
 
         unit = create_plugin_instance()
         with mock.patch.object(unit, '_handleUpdateExcludeRegion') as handlerMock:
@@ -313,7 +313,7 @@ class ExcludeRegionPluginTests(TestCase):  # pylint: disable=too-many-public-met
     @mock.patch('octoprint_excluderegion.current_user')
     def test_on_api_command_updateExcludeRegion_CircularRegion(self, mockCurrentUser):
         """Test the on_api_command method for the 'updateExcludeRegion' command."""
-        mockCurrentUser.is_anonymous.return_value = False
+        mockCurrentUser.is_anonymous = False
 
         unit = create_plugin_instance()
         with mock.patch.object(unit, '_handleUpdateExcludeRegion') as handlerMock:
@@ -335,7 +335,7 @@ class ExcludeRegionPluginTests(TestCase):  # pylint: disable=too-many-public-met
     @mock.patch('octoprint_excluderegion.current_user')
     def test_on_api_command_updateExcludeRegion_unsupportedType(self, mockCurrentUser):
         """Test on_api_command when an invalid type is provided for 'updateExcludeRegion'."""
-        mockCurrentUser.is_anonymous.return_value = False
+        mockCurrentUser.is_anonymous = False
 
         unit = create_plugin_instance()
         with mock.patch.object(unit, '_handleUpdateExcludeRegion') as handlerMock:
@@ -356,7 +356,7 @@ class ExcludeRegionPluginTests(TestCase):  # pylint: disable=too-many-public-met
     @mock.patch('octoprint_excluderegion.current_user')
     def test_on_api_command_deleteExcludeRegion(self, mockCurrentUser):
         """Test on_api_command for the 'deleteExcludeRegion' command."""
-        mockCurrentUser.is_anonymous.return_value = False
+        mockCurrentUser.is_anonymous = False
 
         unit = create_plugin_instance()
         with mock.patch.object(unit, '_handleDeleteExcludeRegion') as handlerMock:
@@ -375,7 +375,7 @@ class ExcludeRegionPluginTests(TestCase):  # pylint: disable=too-many-public-met
     @mock.patch.multiple('octoprint_excluderegion', current_user=mock.DEFAULT, flask=mock.DEFAULT)
     def test_on_api_get_unauthenticated(self, current_user, flask):  # pylint: disable=invalid-name
         """Test the on_api_get method for an unauthenticated user."""
-        current_user.is_anonymous.return_value = True
+        current_user.is_anonymous = True
         flask.jsonify.return_value = "expectedResult"
 
         testRegion = CircularRegion(x=0, y=0, radius=10, id="myId")
@@ -393,7 +393,7 @@ class ExcludeRegionPluginTests(TestCase):  # pylint: disable=too-many-public-met
     @mock.patch.multiple('octoprint_excluderegion', current_user=mock.DEFAULT, flask=mock.DEFAULT)
     def test_on_api_get_authenticated(self, current_user, flask):  # pylint: disable=invalid-name
         """Test the on_api_get method for an authenticated user."""
-        current_user.is_anonymous.return_value = False
+        current_user.is_anonymous = False
         flask.jsonify.return_value = "expectedResult"
 
         testRegion = CircularRegion(x=0, y=0, radius=10, id="myId")

--- a/test/utils.py
+++ b/test/utils.py
@@ -4,9 +4,13 @@
 from __future__ import absolute_import
 from builtins import str
 
-import collections
 import unittest
 import warnings
+
+try:
+    from collections.abc import Mapping
+except ImportError:  # Python 2
+    from collections import Mapping
 
 from callee import Matcher
 
@@ -83,7 +87,7 @@ class TestCase(unittest.TestCase):
         AssertionError
             If the specified value is not a dictionary-like object.
         """
-        if (not isinstance(value, collections.Mapping)):
+        if (not isinstance(value, Mapping)):
             raise AssertionError(self._msg(value, "Value is not a dictionary", msg))
 
     def assertIsString(self, value, msg=None):
@@ -136,7 +140,7 @@ class TestCase(unittest.TestCase):
 
         msg = self._msg(value, "Object properties do not match expectations", msg)
 
-        if (isinstance(value, collections.Mapping)):
+        if (isinstance(value, Mapping)):
             propertiesDict = value  # Already a dict
         else:
             propertiesDict = vars(value)


### PR DESCRIPTION
Hi, I'm an active contributor to OctoPrint core. I helped ship [OctoPrint 2.0.0rc1](https://github.com/OctoPrint/OctoPrint/releases/tag/2.0.0rc1) and I'm now helping plugins stay compatible with the new and upcoming OctoPrint releases, which is why you're receiving this PR.

---

This PR fixes some issues that prevent this plugin from working on OctoPrint 2.x.

In particular:
- Removes usage of `pkg_resources`, which is deprecated and not working in modern python envs (fix #81)
- Fix `current_user.is_anonymous` usage, which is not a callable anymore since OctoPrint 2.x
- Implement `is_api_protected` ([ref](https://docs.octoprint.org/en/main/plugins/mixins.html#octoprint.plugin.SimpleApiPlugin.is_api_protected)) and `is_template_autoescaped` ([ref](https://docs.octoprint.org/en/main/plugins/mixins.html#octoprint.plugin.TemplatePlugin.is_template_autoescaped)), whose missing implementation caused warnings to appear in the OctoPrint logs
- Fix tests on Python 3

This PR supersedes #82.

I tested this PR on both OctoPrint 2.0.0rc4 and the latest stable release 1.11.8, and everything appears to work correctly.

Please remember after merging to bump the plugin version number and publish a new release.